### PR TITLE
arm: dts: msm: update SPM sequences for krait v2.x

### DIFF
--- a/arch/arm/boot/dts/msm8974-v2-pm.dtsi
+++ b/arch/arm/boot/dts/msm8974-v2-pm.dtsi
@@ -26,7 +26,7 @@
 		qcom,saw2-spm-dly= <0x3C102800>;
 		qcom,saw2-spm-ctl = <0x1>;
 		qcom,saw2-spm-cmd-wfi = [03 0b 0f];
-		qcom,saw2-spm-cmd-ret = [42 1b 00 d8 5B 03 d8 5b 0b 00 42 1b 0f];
+		qcom,saw2-spm-cmd-ret = [42 1b 00 d8 5B 03 3B d8 5b 0b 00 42 1b 0f];
 		qcom,saw2-spm-cmd-spc = [00 20 80 10 E8 5B 03 3B E8 5B 82 10 0B
 			30 06 26 30 0F];
 		qcom,saw2-spm-cmd-pc = [00 20 80 10 E8 5B 07 3B E8 5B 82 10 0B
@@ -48,7 +48,7 @@
 		qcom,saw2-spm-dly= <0x3C102800>;
 		qcom,saw2-spm-ctl = <0x1>;
 		qcom,saw2-spm-cmd-wfi = [03 0b 0f];
-		qcom,saw2-spm-cmd-ret = [42 1b 00 d8 5B 03 d8 5b 0b 00 42 1b 0f];
+		qcom,saw2-spm-cmd-ret = [42 1b 00 d8 5B 03 3B d8 5b 0b 00 42 1b 0f];
 		qcom,saw2-spm-cmd-spc = [00 20 80 10 E8 5B 03 3B E8 5B 82 10 0B
 			30 06 26 30 0F];
 		qcom,saw2-spm-cmd-pc = [00 20 80 10 E8 5B 07 3B E8 5B 82 10 0B
@@ -70,7 +70,7 @@
 		qcom,saw2-spm-dly= <0x3C102800>;
 		qcom,saw2-spm-ctl = <0x1>;
 		qcom,saw2-spm-cmd-wfi = [03 0b 0f];
-		qcom,saw2-spm-cmd-ret = [42 1b 00 d8 5B 03 d8 5b 0b 00 42 1b 0f];
+		qcom,saw2-spm-cmd-ret = [42 1b 00 d8 5B 03 3B d8 5b 0b 00 42 1b 0f];
 		qcom,saw2-spm-cmd-spc = [00 20 80 10 E8 5B 03 3B E8 5B 82 10 0B
 			30 06 26 30 0F];
 		qcom,saw2-spm-cmd-pc = [00 20 80 10 E8 5B 07 3B E8 5B 82 10 0B
@@ -92,7 +92,7 @@
 		qcom,saw2-spm-dly= <0x3C102800>;
 		qcom,saw2-spm-ctl = <0x1>;
 		qcom,saw2-spm-cmd-wfi = [03 0b 0f];
-		qcom,saw2-spm-cmd-ret = [42 1b 00 d8 5B 03 d8 5b 0b 00 42 1b 0f];
+		qcom,saw2-spm-cmd-ret = [42 1b 00 d8 5B 03 3B d8 5b 0b 00 42 1b 0f];
 		qcom,saw2-spm-cmd-spc = [00 20 80 10 E8 5B 03 3B E8 5B 82 10 0B
 			30 06 26 30 0F];
 		qcom,saw2-spm-cmd-pc = [00 20 80 10 E8 5B 07 3B E8 5B 82 10 0B


### PR DESCRIPTION
KPSS v2 implemented HW Sequencer to switch Krait power gate
modes. SPM toggle one power control signal to switch to RET/PC sleep.
If the SPM power control for the h/w sequencer is asserted for only
3 AHB clocks, a single cycle pulse is generated which latches the
newMode. The newMode is latched even though the h/w sequencer is
not idle. This causes the state machine to get stuck in LDO_PD state.

Update the retention SPM sequence as recommended by cpu design team
to avoid the issue. Power collapse sequences are already up to date.

CRs-fixed: 566952
Change-Id: I8fe74acf06d67b490f927b504e3aba266667cf9f
Signed-off-by: Venkat Devarasetty <vdevaras@codeaurora.org>